### PR TITLE
fix: `decoreURIComponent` requires bytes to be 0-padded

### DIFF
--- a/bqpb.test.ts
+++ b/bqpb.test.ts
@@ -908,7 +908,7 @@ Deno.test("parseBytes", async (t) => {
       });
       await t.step("parses string", () => {
         const actual = parseBytes(
-          b`\x0a\x00\x0a\x06\x61\x62\x63\xe3\x81\x82`,
+          b`\x0a\x00\x0a\x07\x61\x62\x63\xe3\x81\x82\x0a`,
           "Main",
           {
             "message Main": {
@@ -921,7 +921,7 @@ Deno.test("parseBytes", async (t) => {
           },
         );
         assertEquals(actual, {
-          myField: ["", "abcあ"],
+          myField: ["", "abcあ\n"],
         });
       });
       await t.step("parses submessage", () => {

--- a/bqpb.ts
+++ b/bqpb.ts
@@ -71,7 +71,7 @@ export function decodeUTF8(bytes: Uint8Array): string {
   try {
     // Caveat: this function silently substitutes stray surrogates with U+FFFD.
     return decodeURIComponent(
-      Array.from(bytes).map((b) => `%${b.toString(16)}`).join(""),
+      Array.from(bytes).map((b) => `%${b.toString(16).padStart(2, "0")}`).join("")
     );
   } catch (_e) {
     throw new Error("Invalid UTF-8 sequence");


### PR DESCRIPTION
i.e.: `decodeURIComponent("%a")` should be `decodeURIComponent("%0a")`